### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Ref: Post.authorId > User.id
 | `projectNote`           | Project note for dbdocs                         | `string`  | `null`        |
 | `projectNotePath`       | Project note path to a markdown file for dbdocs | `string`  | `null`        |
 | `output`                | Output directory for the DBML file              | `string`  | `./dbml`      |
-| `outputName`            | Name for the DBML file                          | `string`  | `dbml.schema` |
+| `outputName`            | Name for the DBML file                          | `string`  | `schema.dbml` |
 | `manyToMany`            | Create Many-To-Many join table                  | `boolean` | `true`        |
 | `mapToDbSchema`         | Use mapped table name                           | `boolean` | `true`        |
 | `includeRelationFields` | Include relation fields                         | `boolean` | `true`        |


### PR DESCRIPTION
Default file path is wrong in README.

Correct file path is defined here:
<https://github.com/notiz-dev/prisma-dbml-generator/blob/dbf64722fd29ebbe2d20ad32f3be8dc80b1cf674/src/cli/dbml-generator.ts#L10C37-L10C49>